### PR TITLE
Add global pause feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ class UpdateNetworkGraph
 end
 ````
 
+### Global pause Redis key
+
+To change the exact key that will be put into redis to signal a global pause, use the `@global_pause_token` config option
+
+````ruby
+ResquePauseHelper.configure do |config|
+  config.global_pause_token = "my_custom_token"
+end
+````
+
 The above modification will ensure the job will wait for 30 seconds before abort.
 
 

--- a/README.md
+++ b/README.md
@@ -18,20 +18,58 @@ Usage / Examples
 
 ### Single Job Instance
 
-    require 'resque-pause'
+````ruby
+require 'resque-pause'
 
-    class UpdateNetworkGraph
-      extend Resque::Plugins::Pause
-      @queue = :network_graph
+class UpdateNetworkGraph
+  extend Resque::Plugins::Pause
+  @queue = :network_graph
 
-      def self.perform(repo_id)
-        heavy_lifting
-      end
-    end
+  def self.perform(repo_id)
+  heavy_lifting
+  end
+end
+````
 
-Pause is achieved by storing a pause/queue key in Redis.
 
-Default behaviour...
+### Pausing Individual Queues
+
+To pause the queue:
+
+````ruby
+ResquePauseHelper.pause(:network_graph)
+````
+    
+Then, to unpause the queue:
+
+````ruby
+ResquePauseHelper.unpause(:network_graph)
+````
+
+
+Single-queue pause is achieved by storing a pause/queue key in Redis.
+
+### Global Pause
+
+You can also pause all the queues at once.
+
+To switch on a global pause:
+
+````ruby
+ResquePauseHelper.global_pause_on()
+````
+    
+Then, to remove a global pause:
+
+````ruby
+ResquePauseHelper.global_pause_off()
+````
+
+This kind of pause doesn't interact with any pauses on individual queues. That means, switching the global pause on and off should preserve whatever pauses you might have in place before and even during the global pause period.
+
+An anology would be with light switches and circuit breakers. Positioning light switches is like pausing individual queues. Whatever their position before you flip the breaker (impose a global pause). They'll maintain that position after the global pause.
+
+### Default behaviour
 
 * When the job instance try to execute and the queue is paused, the job is paused for a slice of time.
 * If the queue still paused after this time the job will abort and will be enqueued again with the same arguments.
@@ -58,15 +96,17 @@ By default the time is 10 seconds.
 
 You can define the attribute in your job class in seconds.
 
-    class UpdateNetworkGraph
-      extend Resque::Plugins::Pause
-      @queue = :network_graph
-      @pause_check_interval = 30
+````ruby
+class UpdateNetworkGraph
+  extend Resque::Plugins::Pause
+  @queue = :network_graph
+  @pause_check_interval = 30
 
-      def self.perform(repo_id)
-        heavy_lifting
-      end
-    end
+  def self.perform(repo_id)
+    heavy_lifting
+  end
+end
+````
 
 The above modification will ensure the job will wait for 30 seconds before abort.
 

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -1,0 +1,11 @@
+module ResquePauseHelper
+  class Configuration
+    DEFAULT_GLOBAL_PAUSE_TOKEN = "pause:all"
+
+    attr_accessor :global_pause_token
+
+    def initialize
+      @global_pause_token = DEFAULT_GLOBAL_PAUSE_TOKEN
+    end
+  end
+end

--- a/lib/resque-pause.rb
+++ b/lib/resque-pause.rb
@@ -1,4 +1,5 @@
 require 'resque'
+require File.expand_path(File.join('configuration'), File.dirname(__FILE__))
 require File.expand_path(File.join('resque_pause_helper'), File.dirname(__FILE__))
 require File.expand_path(File.join('resque-pause', 'plugins', 'pause'), File.dirname(__FILE__))
 require File.expand_path(File.join('resque-pause', 'job'), File.dirname(__FILE__))

--- a/lib/resque_pause_helper.rb
+++ b/lib/resque_pause_helper.rb
@@ -48,6 +48,10 @@ module ResquePauseHelper
       Resque.redis.del ResquePauseHelper.configuration.global_pause_token
     end
 
+    def global_pause_on?()
+      !!Resque.redis.get(ResquePauseHelper.configuration.global_pause_token)
+    end
+
     def enqueue_job(args)
       Resque.redis.lpush("queue:#{args[:queue]}", ResquePauseHelper.encode(:class => args[:class].to_s, :args => args[:args]))
     end

--- a/lib/resque_pause_helper.rb
+++ b/lib/resque_pause_helper.rb
@@ -10,8 +10,12 @@ end
 
 module ResquePauseHelper
   class << self
+    GLOBAL_PAUSE_TOKEN = "pause:all"
     def paused?(queue)
-      !Resque.redis.get("pause:queue:#{queue}").nil?
+      ![
+          Resque.redis.get("pause:queue:#{queue}"),
+          Resque.redis.get(GLOBAL_PAUSE_TOKEN)
+      ].all?(&:nil?)
     end
 
     def pause(queue)
@@ -20,6 +24,14 @@ module ResquePauseHelper
 
     def unpause(queue)
       Resque.redis.del "pause:queue:#{queue}"
+    end
+
+    def global_pause_on()
+      Resque.redis.set GLOBAL_PAUSE_TOKEN, true
+    end
+
+    def global_pause_off()
+      Resque.redis.del GLOBAL_PAUSE_TOKEN
     end
 
     def enqueue_job(args)

--- a/spec/resque-pause/plugins/pause_spec.rb
+++ b/spec/resque-pause/plugins/pause_spec.rb
@@ -46,6 +46,83 @@ describe Resque::Plugins::Pause do
     expect(Resque.reserve('test')).to be_nil
   end
 
+  it "should execute the job when queue is unpaused after being paused" do
+    Resque.enqueue(PauseJob)
+    expect(Resque.size('test')).to eq(1)
+
+    job = Resque.reserve('test')
+    ResquePauseHelper.pause('test')
+    job.perform
+    expect(Resque.size('test')).to eq(1)
+
+    ResquePauseHelper.unpause('test')
+
+    expect(PauseJob).to receive(:perform)
+    Resque.reserve('test').perform
+    expect(Resque.size('test')).to eq(0)
+  end
+
+  it "should not reserve the job when global pause is on" do
+    Resque.enqueue(PauseJob)
+    ResquePauseHelper.global_pause_on()
+    expect(PauseJob).not_to receive(:perform)
+
+    expect(Resque.reserve('test')).to be_nil
+  end
+
+  it "should not execute the job when the global pause is on" do
+    Resque.enqueue(PauseJob)
+    expect(Resque.size('test')).to eq(1)
+
+    job = Resque.reserve('test')
+    ResquePauseHelper.global_pause_on()
+    job.perform
+
+    expect(Resque.size('test')).to eq(1)
+  end
+
+  it "should execute the job when the global pause was switched on and then off" do
+    Resque.enqueue(PauseJob)
+    expect(Resque.size('test')).to eq(1)
+
+    job = Resque.reserve('test')
+    ResquePauseHelper.global_pause_on()
+    job.perform
+    expect(Resque.size('test')).to eq(1)
+
+    ResquePauseHelper.global_pause_off()
+
+    expect(PauseJob).to receive(:perform)
+    Resque.reserve('test').perform
+    expect(Resque.size('test')).to eq(0)
+  end
+
+  it "should not execute the job when the queue is paused, and then the global pause is switched on and then back off" do
+    Resque.enqueue(PauseJob)
+    expect(Resque.size('test')).to eq(1)
+
+    job = Resque.reserve('test')
+    ResquePauseHelper.pause('test')
+
+    ResquePauseHelper.global_pause_on()
+    ResquePauseHelper.global_pause_off()
+
+    job.perform
+
+    expect(Resque.size('test')).to eq(1)
+  end
+
+  it "should not reserve the job when the queue is paused, and then the global pause is switched on and then back off" do
+    Resque.enqueue(PauseJob)
+    ResquePauseHelper.pause('test')
+    ResquePauseHelper.global_pause_on()
+    ResquePauseHelper.global_pause_off()
+
+    expect(PauseJob).not_to receive(:perform)
+
+    expect(Resque.reserve('test')).to be_nil
+  end
+
   it "should not change queued jobs when queue is paused" do
     Resque.enqueue(PauseJob, 1)
     Resque.enqueue(PauseJob, 2)

--- a/spec/resque-pause/plugins/pause_spec.rb
+++ b/spec/resque-pause/plugins/pause_spec.rb
@@ -201,4 +201,12 @@ describe Resque::Plugins::Pause do
     Resque.reserve('test').perform
     expect(Resque.size('test')).to eq(0)
   end
+
+  it "should indicate whether the global pause is on" do
+    expect(ResquePauseHelper.global_pause_on?).to be false
+    ResquePauseHelper.global_pause_on()
+    expect(ResquePauseHelper.global_pause_on?).to be true
+    ResquePauseHelper.global_pause_off()
+    expect(ResquePauseHelper.global_pause_on?).to be false
+  end
 end


### PR DESCRIPTION
To understand global pause, compare it with the lighting in a house:

````
pausing/unpausing a queue        <-->         flicking a light switch
global pause                     <-->         circuit breaker
````

The light switches will control which lights are working, but if the circuit is broken, the lights are all off. Additionally, the position of the switches is completely unaffected by the circuit breaker. Whatever position they were in when the breaker broke, they'll be in that same position when the circuit is restored.

This is very helpful for my use-case. It may or may not be a use case you want to accommodate. 

I want to be able to shut down queue processing if my general service health degrades. (In my case, the DBs can get overheated and most (if not all) jobs put load on them.) It would be nice to use the following:

````ruby
Resque.queues.each { |q| ResquePauseHelper.pause(q) }
````

But from where this code would be run (a remote Jenkins job), `Resque.queues` returns an empty array. It doesn't see the queues for some reason.

Another feature this Pull Request has for my use case is the ability to configure the Redis key that signals the queues to pause. When the DBs overheat and I want to back off from them, there are more services that should be a part of the pause-work state. I intend to use Redis to store the signal to initiate the pause. So it helps  orchestration to have some visibility and agency into how `resque-pause` handles things.