### PR TITLE
Remove call to obsolete Gem::Specification#has_rdoc=

### DIFF
--- a/resque-pause.gemspec
+++ b/resque-pause.gemspec
@@ -23,7 +23,6 @@ You can use this functionality to do some maintenance whithout kill workers, for
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.has_rdoc      = false
 
   s.add_dependency('resque', '>= 1.9.10')
   s.add_dependency('multi_json', '~> 1.0')


### PR DESCRIPTION
Address the following deprecation warning on install:

    NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
    Gem::Specification#has_rdoc= called from /usr/local/bundle/bundler/gems/resque-pause-c375dcd2e9db/resque-pause.gemspec:26.